### PR TITLE
Move _events to the instance

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -87,6 +87,9 @@
 	// Picker object
 
 	var Datepicker = function(element, options){
+		this._events = [];
+		this._secondaryEvents = [];
+
 		this._process_options(options);
 
 		this.dates = new DateArray();
@@ -284,8 +287,6 @@
 			}
 			o.showOnFocus = o.showOnFocus !== undefined ? o.showOnFocus : true;
         },
-		_events: [],
-		_secondaryEvents: [],
 		_applyEvents: function(evs){
 			for (var i=0, el, ch, ev; i < evs.length; i++){
 				el = evs[i][0];


### PR DESCRIPTION
## What

Move `_events` from the prototype to the instance to avoid memory leaks.

More info: https://github.com/closeio/closeio/pull/11293.

## Tests

- [x] Local app